### PR TITLE
Migrating to Typst 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 ![contrast](docs/assets/contrast.png)
 
+可以在 [GitHub Actions](https://github.com/Ri-Nai/BIT-Typst-Template/actions/workflows/build.yml) 中查看最新的 PDF 输出。
+
+<!-- 或者在 [Releases](https://github.com/Ri-Nai/BIT-Typst-Template/releases) 中下载 -->
+
 > [!CAUTION]
 > 本模板不保证完全符合学校要求，使用时请自行检查是否符合。 <br>
 > 本人目前就读大二，对毕业设计了解有限，模板为个人制作，可能存在不准确之处。 <br>
@@ -23,7 +27,7 @@
 
 ### 🛠️ 运行环境
 
-💻 Typst 0.12.0
+💻 Typst 0.13.0
 
 ### 🚀 使用方法
 
@@ -33,6 +37,7 @@
 2. 使用包管理器安装：
 
    ```sh
+   cargo install --locked typst-cli
    choco install typst
    winget install typst
    ...
@@ -62,7 +67,9 @@
 
 #### 📚 引用格式
 
-目前使用的 `Typst` 内置的 `gb-7714-2015-numeric` 引用格式与学校要求的格式略有差异。通过 [zotero-chinese/styles](https://github.com/zotero-chinese/styles/blob/main/src/beijing-institute-of-technology/beijing-institute-of-technology.csl) 下载的 `csl` 文件无法直接在 Typst 中使用，还没搞懂如何导入。
+目前使用的 `Typst` 内置的 `gb-7714-2015-numeric` 引用格式与学校要求的格式略有差异。通过 [zotero-chinese/styles](https://github.com/zotero-chinese/styles/blob/main/src/beijing-institute-of-technology/beijing-institute-of-technology.csl) 下载的 `csl` 文件可能效果好些，不过仍未完全满足 Word 中的格式。
+
+据 https://github.com/BITNP/BIThesis/discussions/401#discussioncomment-8198542 反馈，本科生毕业设计（论文）的参考文献格式要求就是 `GB/T 7714-2015`，不需要特别的格式。
 
 #### 🔤 字体格式
 
@@ -87,7 +94,7 @@
 
 ## 🎭 slides-template
 
-此为我在制作[数据结构-研学报告](https://github.com/Ri-Nai/BIT-Lexue-Code/blob/main/Data-Structure/Research-Report/1120231313-%E6%B1%87%E6%8A%A5.typ) 时使用的 Slides 模板，基于 [touying-buaa](https://github.com/Coekjan/touying-buaa) 项目。
+此为我在制作[数据结构-研学报告](https://github.com/Ri-Nai/BIT-Lexue-Code/blob/main/Data-Structure/Research-Report/1120231313-%E6%B1%87%E6%8A%A5.typ) 时使用的 Slides 模板，完全基于 [touying-buaa](https://github.com/Coekjan/touying-buaa) 项目。
 
 ![example](docs/assets/example-touying.png)
 

--- a/undergraduate-thesis-template/main.typ
+++ b/undergraduate-thesis-template/main.typ
@@ -278,12 +278,11 @@ $
       columns: 10,
       [1],
       ..range(2, n + 1).map(x => table.cell(
-          fill: if range(2, calc.floor(calc.sqrt(x)) + 1).all(y => calc.rem-euclid(x, y) != 0) {
-            luma(200)
-          },
-          str(x),
-        ),
-      )),
+        fill: if range(2, calc.floor(calc.sqrt(x)) + 1).all(y => calc.rem-euclid(x, y) != 0) {
+          luma(200)
+        },
+        str(x),
+      ))
     ),
   )
 ]

--- a/undergraduate-thesis-template/pages/contents.typ
+++ b/undergraduate-thesis-template/pages/contents.typ
@@ -1,6 +1,6 @@
 #import "../utils/ziti.typ": zh, zihao
 
-// inspired from 璜珀's blog https://blog.hpcesia.com/posts/5252cfe9/ 
+// inspired from 璜珀's blog https://blog.hpcesia.com/posts/5252cfe9/
 #let contents() = {
   align(center)[
     #v(0.6em)
@@ -8,31 +8,33 @@
       size: zh("三号"),
       font: "SimHei",
       "目　录",
-    )<contents>
+    )
     #v(1.8em)
   ]
 
 
   context {
-    let contents-location = locate(<contents>)
+    let contents-location = here()
     show outline.entry: it => {
       let loc = it.element.location()
       link(
         loc,
-        it.body,
-      )
-      h(0.5em)
-      box(width: 1fr, it.fill)
-      let before = loc.position().page < contents-location.position().page
-      link(
-        loc,
-        numbering(
-          if before { "I" } else { "1" },
-          ..counter(page).at(loc),
+        it.indented(
+          it.prefix(),
+          {
+            it.body()
+            h(0.5em)
+            box(width: 1fr, it.fill)
+            let before = loc.position().page < contents-location.position().page
+            numbering(
+              if before { "I" } else { "1" },
+              ..counter(page).at(loc),
+            )
+          },
         ),
       )
     }
-
+    v(-1em)
     outline(title: [], indent: 2em)
   }
   pagebreak()


### PR DESCRIPTION
主要是改了 outline，别的地方暂时没发现有什么问题

https://github.com/Ri-Nai/BIT-Typst-Template/blob/dev/undergraduate-thesis-template/pages/contents.typ#L18-#L36
```typst
#show outline.entry: it => {
  let loc = it.element.location()
  link(
    loc,
    it.indented(
      it.prefix(),
      {
        it.body()
        h(0.5em)
        box(width: 1fr, it.fill)
        let before = loc.position().page < contents-location.position().page
        numbering(
          if before { "I" } else { "1" },
          ..counter(page).at(loc),
        )
      },
    ),
  )
}
```
