### PR TITLE
🐛 修复了declare的拼写问题

### DIFF
--- a/undergraduate-thesis-template/samples/sample.typ
+++ b/undergraduate-thesis-template/samples/sample.typ
@@ -28,7 +28,7 @@
   author: "杨紫诺",
   student-id: "1120231313",
   guide-teacher: "暂无求包养",
-  declear: false,
+  declare: false,
   date: datetime(year: 2024, month: 1, day: 19),
 )
 

--- a/undergraduate-thesis-template/template.typ
+++ b/undergraduate-thesis-template/template.typ
@@ -29,7 +29,7 @@
   student-id: "",
   guide-teacher: "",
   date: datetime.today(),
-  declear: true,
+  declare: true,
   abstract-content: [],
   abstract-en-content: [],
   keywords: (),
@@ -73,7 +73,7 @@
   )
 
   // 生成原创性声明
-  if declear { declaration() }
+  if declare { declaration() }
 
   // 设置文档显示样式：
   // - show-paper-header: 显示论文页眉


### PR DESCRIPTION
用的时候感觉 `declear` 打着好别扭, 打字的时候会自己纠错到 `declare`. 字典里查了一下应该是没有这个词的 (?)

所以就把这个改了 ()